### PR TITLE
Introduce is_non_empty_array

### DIFF
--- a/app/Options/Support/InputValidator.php
+++ b/app/Options/Support/InputValidator.php
@@ -108,7 +108,7 @@ class InputValidator
 	/** @param mixed $value */
 	private function validateWithConstraints($value): void
 	{
-		if (! is_array($this->constraints) || $this->constraints === []) {
+		if (! is_non_empty_array($this->constraints)) {
 			return;
 		}
 


### PR DESCRIPTION
@tfirdaus I see you are checking for non-empty arrays in many places. This PR replaces only 1 occurrence.

You can add this to your Utils package 🎁 
```php
function is_non_empty_array(mixed $array): bool
{
    return is_array($array) && $array !== [];
}
```
